### PR TITLE
Use named function expression

### DIFF
--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -39,10 +39,12 @@ export default function useForm(callback, validationSchema) {
     }));
   };
 
+  const setValuesCallback = passedValues => setValues(validationSchema.cast(passedValues));
+
   return {
     handleChange,
     handleSubmit,
-    setValues: passedValues => setValues(validationSchema.cast(passedValues)),
+    setValues: setValuesCallback,
     validationError,
     values: validationSchema.cast(values),
     isValid: validationSchema.isValidSync(values),


### PR DESCRIPTION
Use named function expression instead of an anonymous function. For some reason, the setValues is undefined after production build/deploy in Escola. So I'm hoping using a named function expression will fix this issue.